### PR TITLE
Fix: CLI silently drops/renames config keys (e.g. blur_threshold ignored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to 360 Extractor Pro will be documented in this file.
 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CLI config keys silently dropped**: the CLI hand-built the settings dict it
+  passed to the processor and omitted several keys (`blur_threshold`,
+  `interpolation_mode`, `ai_confidence`, `ai_invert_mask`, `feather_mask`,
+  `sharpening_strength`) and misread others (`interval_value`/`interval_unit`
+  were read from the wrong key and the unit forced to `Seconds`; `output_format`
+  was read as `format`). As a result, e.g. `blur_threshold` from the config was
+  ignored and the processor's hard-coded default of `100.0` was always used.
+  CLI settings are now seeded from `SettingsManager.DEFAULT_SETTINGS` and merged
+  as defaults < config file < CLI args, so every key flows through. Older configs
+  using `interval`/`format` are still accepted as aliases.
+- **`quality` missing from defaults**: `quality` was read by the processor but
+  absent from `DEFAULT_SETTINGS`; it is now defined there (`95`).
+
+### Added
+- **`build_settings()`** in `core.settings_manager`, a unit-testable function for
+  the defaults/config/CLI merge used by CLI mode.
+- **Tests** (`tests/test_cli_settings.py`), including a regression guard that
+  asserts every key the processor reads via `settings.get(...)` is present in the
+  assembled settings dict.
+
+### Docs
+- **`docs/SETTINGS.md`**: corrected the example config (which used non-functional
+  `interval`/`format`/`ai_mask`/`adaptive` keys), added a complete key reference
+  table generated from the defaults, and fixed the adaptive Motion Threshold
+  default (`0.5`, not `5.0`).
+
 ## [3.1.0] - 2026-06-09
 
 ### Added

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -32,7 +32,7 @@ This guide explains the various settings available in the 360 Extractor Pro GUI 
     *   *Generate Mask:* Create a mask file for the detected person (for inpainting).
 *   **Intelligent Keyframing (Adaptive Interval):**
     *   *Enable:* Toggle adaptive extraction.
-    *   *Motion Threshold:* Adjust sensitivity (0.0-100.0). Higher values require more motion to trigger extraction. Default is 5.0.
+    *   *Motion Threshold:* Adjust sensitivity (mean optical-flow magnitude between kept frames). Higher values require more motion to trigger extraction. Default is 0.5. (CLI: `--motion-threshold`.)
 *   **Telemetry (Export GPS/IMU):**
     *   *Enable:* Extract GPS/IMU metadata (GoPro GPMF, Insta360 CAMM, DJI SRT, or a sidecar `.gpx`) and embed GPS coordinates into each output image's EXIF.
     *   *Altitude Source:* For DJI clips that expose both a relative and an absolute altitude (`[rel_alt: … abs_alt: …]`), choose which one to write to EXIF. **Absolute** (above sea level) is recommended for RealityScan/COLMAP geo-referencing and scale; **Relative** is height above the takeoff point. Other devices carry a single altitude and ignore this setting. Default is `absolute`. (CLI: `--altitude-mode`.)
@@ -57,26 +57,73 @@ The application supports three naming conventions:
 
 ## Configuration Files (JSON)
 
-You can define job settings in a JSON file for reuse or complex configurations. CLI arguments override settings found in the configuration file.
+You can define job settings in a JSON file for reuse or complex configurations.
 
-### Structure Example (`config.json`):
+CLI arguments override settings in the config file, which in turn override the
+built-in defaults (`SettingsManager.DEFAULT_SETTINGS`). Any key you omit falls
+back to its default; you only need to specify what you want to change.
+
+### Minimal example (`config.json`):
 
 ```json
 {
     "input": "videos/holiday.mp4",
     "output": "processed/holiday",
     "is_360": true,
-    "interval": 2.0,
-    "format": "png",
-    "camera_count": 6,
-    "active_cameras": [0, 1, 2, 3],
-    "resolution": 2048,
-    "quality": 100,
-    "ai_mask": true,
-    "adaptive": false,
+    "interval_value": 2.0,
+    "interval_unit": "Seconds",
+    "output_format": "png",
+    "camera_count": 8,
+    "layout_mode": "fibonacci",
+    "active_cameras": [0, 1, 2, 3, 4, 5, 6, 7],
+    "ai_mode": "Generate Mask",
     "naming_mode": "realityscan"
 }
 ```
 
 > Set `"is_360": false` (or pass `--flat`) to process standard, non-panoramic
 > media without reprojection.
+
+### Complete key reference
+
+Every supported key, with its default value. Keys are identical in the GUI,
+the JSON config, and the CLI; the config file accepts exactly these names.
+
+| Key | Default | Notes |
+|-----|---------|-------|
+| `is_360` | `true` | Reproject equirectangular input. `false` / `--flat` for standard media. |
+| `resolution` | `2048` | Output width/height in px (square). |
+| `fov` | `90` | Horizontal field of view per virtual camera, in degrees. |
+| `camera_count` | `6` | Number of virtual pinhole cameras (2–36). |
+| `pitch_offset` | `0` | Vertical tilt of horizontal cameras, in degrees. |
+| `layout_mode` | `"ring"` | `ring`, `cube`, or `fibonacci`. |
+| `active_cameras` | *(all)* | List of camera indices to keep, e.g. `[0,1,4]`. Omit for all. |
+| `ai_mode` | `"None"` | `None`, `Generate Mask`, or `Skip Frame`. |
+| `ai_confidence` | `0.25` | Detection confidence threshold (0–1). |
+| `ai_invert_mask` | `true` | `true` = white keeps / black removes (COLMAP/RealityScan convention). |
+| `ai_detect_humans` | `true` | Include the person class. |
+| `ai_detect_vehicles` | `false` | Include the vehicle classes. |
+| `ai_detect_plants` | `false` | Include the plant classes. |
+| `ai_custom_classes` | `""` | Comma-separated extra class names. |
+| `quality` | `95` | JPEG quality (1–100); ignored for PNG. |
+| `output_format` | `"jpg"` | `jpg` or `png`. |
+| `custom_output_dir` | `""` | Overrides the default per-video output folder. |
+| `interval_value` | `1.0` | Sampling interval (paired with `interval_unit`). |
+| `interval_unit` | `"Seconds"` | `Seconds` or `Frames`. |
+| `blur_filter_enabled` | `false` | Enable blur rejection. |
+| `smart_blur_enabled` | `false` | Relative (rolling-average) blur rejection on top of the floor. |
+| `blur_threshold` | `100.0` | Sharpness floor (variance of Laplacian); higher is stricter. |
+| `sharpening_enabled` | `false` | Apply an unsharp mask after reprojection. |
+| `sharpening_strength` | `0.5` | Unsharp-mask strength when enabled. |
+| `adaptive_mode` | `false` | Motion-based (intelligent) keyframing. |
+| `adaptive_threshold` | `0.5` | Motion threshold (mean optical-flow magnitude) for adaptive keyframing. |
+| `export_telemetry` | `false` | Extract GPS/IMU and embed GPS in EXIF. |
+| `altitude_mode` | `"absolute"` | `absolute` or `relative` (DJI clips with both altitudes). |
+| `interpolation_mode` | `"linear"` | Reprojection interpolation: `linear` or `lanczos`. |
+| `feather_mask` | `false` | Soften mask edges instead of a hard binary mask. |
+| `naming_mode` | `"realityscan"` | `realityscan`, `simple`, or `custom`. |
+| `image_pattern` | `"{filename}_frame{frame}_{camera}"` | Custom mode only. |
+| `mask_pattern` | `"{filename}_frame{frame}_{camera}_mask"` | Custom mode only. |
+
+> Older config files using `interval` and `format` are still accepted as
+> aliases for `interval_value` and `output_format`.

--- a/src/core/settings_manager.py
+++ b/src/core/settings_manager.py
@@ -20,6 +20,7 @@ class SettingsManager:
         "ai_detect_vehicles": False,
         "ai_detect_plants": False,
         "ai_custom_classes": "",
+        "quality": 95,
         "output_format": "jpg",
         "custom_output_dir": "",
         "interval_value": 1.0,
@@ -97,3 +98,90 @@ class SettingsManager:
     def get_all(self):
         """Return a copy of all settings."""
         return self.settings.copy()
+
+def build_settings(args, config, active_cameras=None, output_path=""):
+    """Assemble the settings dict consumed by the processor.
+
+    Precedence, lowest to highest: ``SettingsManager.DEFAULT_SETTINGS`` < config
+    file < explicit CLI arguments. Seeding from ``DEFAULT_SETTINGS`` guarantees
+    every key the processor reads is present even when the config file omits it,
+    which avoids silent fallbacks to hard-coded defaults (for example, a missing
+    ``blur_threshold`` previously reverted to ``100.0`` no matter what the config
+    file said, because the CLI never copied the key through).
+
+    ``args`` is the parsed ``argparse.Namespace``. ``active_cameras`` and
+    ``output_path`` are resolved by the caller (they involve validation / IO).
+    """
+    settings = SettingsManager.DEFAULT_SETTINGS.copy()
+
+    # Config file overrides defaults. Keys share the names used in
+    # DEFAULT_SETTINGS and the processor (interval_value, output_format,
+    # blur_threshold, interpolation_mode, ...), so they map straight through.
+    settings.update(config)
+
+    # Backward-compatible aliases for older config files.
+    if 'interval' in config and 'interval_value' not in config:
+        settings['interval_value'] = config['interval']
+    if 'format' in config and 'output_format' not in config:
+        settings['output_format'] = config['format']
+
+    # --- Explicit CLI arguments override the config file (when provided) ---
+    cli_overrides = {
+        'resolution': args.resolution,
+        'camera_count': args.camera_count,
+        'quality': args.quality,
+        'layout_mode': args.layout,
+        'output_format': args.format,
+        'altitude_mode': args.altitude_mode,
+        'ai_custom_classes': args.custom_classes,
+        'naming_mode': args.naming_mode,
+        'image_pattern': args.image_pattern,
+        'mask_pattern': args.mask_pattern,
+    }
+    for key, value in cli_overrides.items():
+        if value is not None:
+            settings[key] = value
+
+    # --interval is expressed in seconds.
+    if args.interval is not None:
+        settings['interval_value'] = args.interval
+        settings['interval_unit'] = 'Seconds'
+
+    # Flat (non-360) input.
+    if getattr(args, 'flat', False):
+        settings['is_360'] = False
+
+    # AI mode: CLI flags win; otherwise honor the legacy boolean 'ai' config key.
+    if getattr(args, 'ai_skip', False):
+        settings['ai_mode'] = 'Skip Frame'
+    elif getattr(args, 'ai_mask', False) or getattr(args, 'ai', False):
+        settings['ai_mode'] = 'Generate Mask'
+    elif settings.get('ai_mode', 'None') == 'None' and config.get('ai', False):
+        settings['ai_mode'] = 'Generate Mask'
+
+    # Adaptive interval.
+    if getattr(args, 'adaptive', False):
+        settings['adaptive_mode'] = True
+    if args.motion_threshold is not None:
+        settings['adaptive_threshold'] = args.motion_threshold
+
+    # Telemetry.
+    if getattr(args, 'export_telemetry', False):
+        settings['export_telemetry'] = True
+
+    # AI detection targets.
+    if args.targets is not None:
+        targets = [t.strip().lower() for t in args.targets.split(',')]
+        settings['ai_detect_humans'] = 'humans' in targets
+        settings['ai_detect_vehicles'] = 'vehicles' in targets
+        settings['ai_detect_plants'] = 'plants' in targets
+
+    # A supplied pattern without an explicit mode implies custom naming.
+    if (args.image_pattern or args.mask_pattern) and not args.naming_mode:
+        settings['naming_mode'] = 'custom'
+
+    # Values resolved by the caller.
+    settings['active_cameras'] = active_cameras
+    settings['custom_output_dir'] = output_path
+
+    return settings

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QCoreApplication
 
 from ui.main_window import MainWindow
-from core.settings_manager import SettingsManager
+from core.settings_manager import SettingsManager, build_settings
 from core.job import Job
 from core.processor import ProcessingWorker
 from utils.logger import logger
@@ -152,103 +152,9 @@ def run_cli(args):
             logger.error(f"Error: Invalid format for active-cameras: {active_cameras_str}")
             sys.exit(1)
 
-    # Prepare settings
-    # Note: args.interval etc are None if not provided because I removed default in add_argument for some
-    # Actually I should verify defaults logic. 
-    # To properly support "CLI overrides Config overrides Default", I removed defaults from add_argument 
-    # except for flags where it's trickier.
-    # Let's adjust get_arg logic to handle defaults manually.
-    
-    interval = args.interval if args.interval is not None else config.get('interval', 1.0)
-    fmt = args.format if args.format is not None else config.get('format', 'jpg')
-    cam_count = args.camera_count if args.camera_count is not None else config.get('camera_count', 6)
-    quality = args.quality if args.quality is not None else config.get('quality', 95)
-    resolution = args.resolution if args.resolution is not None else config.get('resolution', 2048)
-    layout_mode = args.layout if args.layout is not None else config.get('layout_mode', 'ring')
-
-    # 360 vs flat (non-360) input. --flat forces non-360; otherwise use config.
-    is_360 = config.get('is_360', True)
-    if args.flat:
-        is_360 = False
-    
-    # AI Mode logic
-    ai_mode = 'None'
-    if args.ai_skip:
-        ai_mode = 'Skip Frame'
-    elif args.ai_mask or args.ai:
-        ai_mode = 'Generate Mask'
-    else:
-        # Check config
-        ai_mode = config.get('ai_mode', 'None')
-        # Handle legacy config 'ai': boolean if ai_mode is still None
-        if ai_mode == 'None' and config.get('ai', False):
-            ai_mode = 'Generate Mask'
-
-    # Adaptive Mode logic
-    adaptive = args.adaptive
-    if not adaptive:
-        adaptive = config.get('adaptive_mode', False)
-    
-    motion_threshold = args.motion_threshold if args.motion_threshold is not None else config.get('adaptive_threshold', 0.5)
-    
-    export_telemetry = args.export_telemetry
-    if not export_telemetry:
-        export_telemetry = config.get('export_telemetry', False)
-
-    altitude_mode = args.altitude_mode if args.altitude_mode is not None else config.get('altitude_mode', 'absolute')
-
-    # AI Targets logic
-    ai_detect_humans = config.get('ai_detect_humans', True)
-    ai_detect_vehicles = config.get('ai_detect_vehicles', False)
-    ai_detect_plants = config.get('ai_detect_plants', False)
-    
-    if args.targets is not None:
-        targets_list = [t.strip().lower() for t in args.targets.split(',')]
-        ai_detect_humans = 'humans' in targets_list
-        ai_detect_vehicles = 'vehicles' in targets_list
-        ai_detect_plants = 'plants' in targets_list
-
-    ai_custom_classes = args.custom_classes if args.custom_classes is not None else config.get('ai_custom_classes', "")
-
-    # Naming Configuration
-    naming_mode = args.naming_mode or config.get('naming_mode', 'realityscan')
-    image_pattern = args.image_pattern or config.get('image_pattern')
-    mask_pattern = args.mask_pattern or config.get('mask_pattern')
-    
-    # Auto-switch to custom if patterns provided
-    if (args.image_pattern or args.mask_pattern) and not args.naming_mode:
-        naming_mode = 'custom'
-
-    settings = {
-        'is_360': is_360,
-        'interval_value': interval,
-        'interval_unit': 'Seconds',
-        'output_format': fmt,
-        'camera_count': cam_count,
-        'quality': quality,
-        'layout_mode': layout_mode,
-        'ai_mode': ai_mode,
-        'custom_output_dir': output_path,
-        'active_cameras': active_cameras,
-        'ai_detect_humans': ai_detect_humans,
-        'ai_detect_vehicles': ai_detect_vehicles,
-        'ai_detect_plants': ai_detect_plants,
-        'ai_custom_classes': ai_custom_classes,
-        # Defaults for others (could be exposed to config later)
-        'resolution': resolution,
-        'fov': config.get('fov', 90),
-        'pitch_offset': config.get('pitch_offset', 0),
-        'blur_filter_enabled': config.get('blur_filter_enabled', False),
-        'smart_blur_enabled': config.get('smart_blur_enabled', False),
-        'sharpening_enabled': config.get('sharpening_enabled', False),
-        'adaptive_mode': adaptive,
-        'adaptive_threshold': motion_threshold,
-        'export_telemetry': export_telemetry,
-        'altitude_mode': altitude_mode,
-        'naming_mode': naming_mode,
-        'image_pattern': image_pattern,
-        'mask_pattern': mask_pattern
-    }
+    # Build the settings dict the processor consumes.
+    # Precedence: DEFAULT_SETTINGS < config file < explicit CLI arguments.
+    settings = build_settings(args, config, active_cameras, output_path)
 
     jobs = [Job(file_path=f, settings=settings) for f in files_to_process]
     

--- a/tests/test_cli_settings.py
+++ b/tests/test_cli_settings.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for CLI settings assembly (``core.settings_manager.build_settings``).
+
+These guard against config keys being silently dropped or renamed between the
+config file, the CLI, and what the processor actually reads — the class of bug
+where, e.g., ``blur_threshold`` from the JSON never reached the processor and a
+hard-coded default of 100.0 was used instead.
+"""
+import argparse
+import os
+import re
+import sys
+import unittest
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from core.settings_manager import SettingsManager, build_settings
+
+SRC_DIR = os.path.join(os.path.dirname(__file__), '..', 'src')
+
+
+def make_args(**overrides):
+    """An argparse.Namespace with every CLI destination defaulted.
+
+    Store-true flags default to False; everything else defaults to None, matching
+    how argparse hands values to ``run_cli``.
+    """
+    defaults = dict(
+        config=None, input=None, output=None,
+        interval=None, format=None,
+        ai=False, ai_mask=False, ai_skip=False,
+        camera_count=None, quality=None, active_cameras=None,
+        resolution=None, layout=None, flat=False,
+        adaptive=False, motion_threshold=None,
+        export_telemetry=False, altitude_mode=None,
+        targets=None, custom_classes=None,
+        naming_mode=None, image_pattern=None, mask_pattern=None,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def processor_setting_keys():
+    """Every key read via ``settings.get('...')`` in the processor / job modules."""
+    keys = set()
+    pattern = re.compile(r"settings\.get\(\s*['\"]([a-zA-Z_0-9]+)['\"]")
+    for rel in ('core/processor.py', 'core/job.py'):
+        with open(os.path.join(SRC_DIR, rel), encoding='utf-8') as fh:
+            keys.update(pattern.findall(fh.read()))
+    return keys
+
+
+class TestBuildSettings(unittest.TestCase):
+    """Tests for the defaults < config < CLI precedence and key coverage."""
+
+    def test_every_processor_key_is_provided(self):
+        """The settings dict must contain every key the processor reads.
+
+        Regression guard for the dropped-key bug: a key the processor reads
+        (e.g. 'blur_threshold' or 'interpolation_mode') must never be absent and
+        silently fall back to a hard-coded default inside the processor.
+        """
+        settings = build_settings(make_args(), config={})
+        missing = processor_setting_keys() - set(settings)
+        self.assertEqual(
+            missing, set(),
+            f"settings is missing keys the processor reads: {sorted(missing)}"
+        )
+
+    def test_config_overrides_defaults(self):
+        """Values present in the config file must reach the settings dict."""
+        config = {
+            'blur_threshold': 27.0,
+            'interpolation_mode': 'lanczos',
+            'interval_value': 8,
+            'interval_unit': 'Frames',
+            'camera_count': 10,
+        }
+        settings = build_settings(make_args(), config=config)
+        self.assertEqual(settings['blur_threshold'], 27.0)
+        self.assertEqual(settings['interpolation_mode'], 'lanczos')
+        self.assertEqual(settings['interval_value'], 8)
+        self.assertEqual(settings['interval_unit'], 'Frames')
+        self.assertEqual(settings['camera_count'], 10)
+
+    def test_omitted_key_uses_documented_default(self):
+        """An omitted key falls back to the DEFAULT_SETTINGS value, not a surprise."""
+        settings = build_settings(make_args(), config={})
+        self.assertEqual(
+            settings['blur_threshold'],
+            SettingsManager.DEFAULT_SETTINGS['blur_threshold'],
+        )
+
+    def test_cli_overrides_config(self):
+        """Explicit CLI arguments win over the config file."""
+        config = {'resolution': 2048, 'camera_count': 10}
+        settings = build_settings(make_args(resolution=4096, camera_count=6), config=config)
+        self.assertEqual(settings['resolution'], 4096)
+        self.assertEqual(settings['camera_count'], 6)
+
+    def test_cli_interval_overrides_in_seconds(self):
+        """--interval is in seconds and overrides the config cadence."""
+        config = {'interval_value': 8, 'interval_unit': 'Frames'}
+        settings = build_settings(make_args(interval=2.0), config=config)
+        self.assertEqual(settings['interval_value'], 2.0)
+        self.assertEqual(settings['interval_unit'], 'Seconds')
+
+    def test_legacy_interval_and_format_aliases(self):
+        """Older config files used 'interval' and 'format' rather than the
+        'interval_value' / 'output_format' keys."""
+        config = {'interval': 2.0, 'format': 'png'}
+        settings = build_settings(make_args(), config=config)
+        self.assertEqual(settings['interval_value'], 2.0)
+        self.assertEqual(settings['output_format'], 'png')
+
+    def test_active_cameras_and_output_passthrough(self):
+        settings = build_settings(
+            make_args(), config={}, active_cameras=[0, 1, 2], output_path='/tmp/out'
+        )
+        self.assertEqual(settings['active_cameras'], [0, 1, 2])
+        self.assertEqual(settings['custom_output_dir'], '/tmp/out')
+
+    def test_targets_flag_sets_detection(self):
+        settings = build_settings(make_args(targets='humans,vehicles'), config={})
+        self.assertTrue(settings['ai_detect_humans'])
+        self.assertTrue(settings['ai_detect_vehicles'])
+        self.assertFalse(settings['ai_detect_plants'])
+
+    def test_ai_mode_flags_and_legacy_boolean(self):
+        self.assertEqual(build_settings(make_args(ai_skip=True), {})['ai_mode'], 'Skip Frame')
+        self.assertEqual(build_settings(make_args(ai_mask=True), {})['ai_mode'], 'Generate Mask')
+        # Legacy boolean 'ai' key in an older config still enables masking.
+        self.assertEqual(build_settings(make_args(), {'ai': True})['ai_mode'], 'Generate Mask')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I noticed that the blur_threshold in my json config file used from the CLI didn't bite and tasked claude with fixing it.
We found lots of json settings didn't work correctly.
Included:
* fix
* tests
* complete docs for json config