### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to 360 Extractor Pro will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.1] - 2026-06-17
 
 ### Fixed
 - **CLI config keys silently dropped**: the CLI hand-built the settings dict it

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,4 +1,4 @@
 APP_NAME = "360 Extractor"
-VERSION = "3.1.0"
+VERSION = "3.1.1"
 AUTHOR = "Nicolas Diolez"
 LICENSE = "AGPL-3.0"


### PR DESCRIPTION
Bumps version to 3.1.1.

Includes the CLI config-key fix (#11, already on main) and:
- `VERSION` 3.1.0 → 3.1.1
- CHANGELOG: `[Unreleased]` → `[3.1.1] - 2026-06-17`
- CHANGELOG: restore the missing 'Keep a Changelog' header line

🤖 Generated with [Claude Code](https://claude.com/claude-code)