### PR TITLE
feat(ai): per-face masking scope — v3.2.0 (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to 360 Extractor Pro will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.1] - 2026-06-17
 
 ### Fixed
 - **CLI config keys silently dropped**: the CLI hand-built the settings dict it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to 360 Extractor Pro will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-06-27
+
+### Added
+- **Per-face AI masking scope** (issue #14): AI masking can now be restricted to
+  a subset of cubemap faces instead of being applied to every view. This avoids
+  YOLO masking people in paintings/posters on the walls when you only need to
+  remove the operator (e.g. on the `Down` or `Back` face). New setting
+  `ai_mask_cameras` (list of face names; empty = all faces, the previous
+  behavior). Exposed in the GUI as face checkboxes under "AI Processing" (Cube
+  layout), and on the CLI via `--ai-mask-cameras "Down,Back"`. Inference only
+  runs on the selected faces, so unselected faces are also a little cheaper.
+
 ## [3.1.1] - 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 High-performance desktop application and command-line tool for 360° and standard video/image preprocessing. This tool generates optimized datasets for Gaussian Splatting and photogrammetry (COLMAP, RealityScan) by converting equirectangular media into rectilinear pinhole views and removing operators using AI.
 
-> **v3.1.0** - Added **DJI altitude extraction** (rel/abs) with a selectable EXIF altitude source. See the [CHANGELOG](CHANGELOG.md) for details and prior releases.
+> **v3.2.0** - Added **per-face AI masking**: restrict operator removal to specific cubemap faces (e.g. mask only `Down`/`Back`) so people in paintings/posters on the other faces are left untouched. See the [CHANGELOG](CHANGELOG.md) for details and prior releases.
 
 ## Key Features
 
@@ -10,7 +10,7 @@ High-performance desktop application and command-line tool for 360° and standar
 - **Standard (Non-360) Media:** Process regular video and images as-is — every filter (blur, AI masking, sharpening, telemetry) still applies, without equirectangular reprojection.
 - **Dual Interface:** Graphical UI for ease of use and CLI for automation.
 - **Advanced Control:** Multiple layouts (Ring, Cube Map, Fibonacci), inclination settings, and selective camera extraction.
-- **AI-Powered:** Automatic operator/object removal (supports 80 COCO classes like humans, vehicles, plants) with adjustable confidence, mask inversion, and intelligent motion-based keyframing.
+- **AI-Powered:** Automatic operator/object removal (supports 80 COCO classes like humans, vehicles, plants) with adjustable confidence, mask inversion, per-face masking scope, and intelligent motion-based keyframing.
 - **Metadata Integration:** Extract GPS/IMU data (GoPro, Insta360, DJI) and embed into EXIF.
 - **Quality Control:** Automatic blur detection, filtering, and optional **Lanczos interpolation** for maximum sharpness.
 - **AI-Powered Masking:** Next-gen operator removal with **Native Softness** (probabilistic alpha blending) for seamless photogrammetry integration.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -36,6 +36,7 @@ python src/main.py --input <video_path> --output <output_dir> [options]
 | `--ai-mask` | Enable AI masking (Generate Mask) for operator removal. | `False` |
 | `--ai-skip` | Enable AI frame skipping (discard frames with persons). | `False` |
 | `--ai` | Alias for `--ai-mask` (for backward compatibility). | `False` |
+| `--ai-mask-cameras` | Restrict AI masking to these faces only, comma-separated (e.g. `Down` or `Back,Down`). Cube faces: `Front,Right,Back,Left,Up,Down`; ring/fibonacci: `View_0,View_1,…`. Empty = all faces. | All |
 | `--adaptive` | Enable intelligent keyframing (skip static scenes). | `False` |
 | `--motion-threshold` | Sensitivity for motion detection (0.0-100.0). Higher = needs more motion to extract. | `5.0` |
 | `--export-telemetry` | Extract GPS/IMU metadata and embed it into output images (EXIF). | `False` |
@@ -59,13 +60,20 @@ python src/main.py --input videos/trip.mp4 --output frames/trip --active-cameras
 ```
 *Camera Indices for 6-camera layout: 0:Front, 1:Right, 2:Back, 3:Left, 4:Up, 5:Down.*
 
-### 3. Standard (Non-360) Media
+### 3. Mask the Operator on One Face Only
+Generate masks but restrict them to the `Down` face (the operator/monopod),
+leaving people in paintings or posters on the other faces untouched.
+```bash
+python src/main.py --input videos/museum.mp4 --output frames/museum --layout cube --ai-mask --ai-mask-cameras "Down"
+```
+
+### 4. Standard (Non-360) Media
 Process a regular (non-panoramic) video or image without reprojection.
 ```bash
 python src/main.py --input clips/interview.mp4 --output frames/interview --flat
 ```
 
-### 4. Using a Config File
+### 5. Using a Config File
 Run a job defined in a JSON file.
 ```bash
 python src/main.py --config my_job.json

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -105,6 +105,7 @@ the JSON config, and the CLI; the config file accepts exactly these names.
 | `ai_detect_vehicles` | `false` | Include the vehicle classes. |
 | `ai_detect_plants` | `false` | Include the plant classes. |
 | `ai_custom_classes` | `""` | Comma-separated extra class names. |
+| `ai_mask_cameras` | *(all)* | Restrict masking to these faces only, e.g. `["Down"]` or `["Back","Down"]`. Cube faces: `Front,Right,Back,Left,Up,Down`; ring/fibonacci: `View_0,View_1,…`. Empty/omitted = mask every face. |
 | `quality` | `95` | JPEG quality (1–100); ignored for PNG. |
 | `output_format` | `"jpg"` | `jpg` or `png`. |
 | `custom_output_dir` | `""` | Overrides the default per-video output folder. |

--- a/src/core/processor.py
+++ b/src/core/processor.py
@@ -11,6 +11,7 @@ from core.ai_model import AIService
 from core.motion_detector import MotionDetector
 from core.telemetry import TelemetryHandler
 from core.ai_classes import PRESETS, parse_custom_classes
+from core.settings_manager import normalize_mask_faces
 from utils.file_manager import FileManager
 from utils.image_utils import ImageUtils
 from utils.logger import logger
@@ -185,6 +186,14 @@ class ProcessingWorker(QObject):
             ai_confidence = job.settings.get('ai_confidence', 0.25)
             ai_invert_mask = job.settings.get('ai_invert_mask', True)
             ai_feather_mask = job.settings.get('feather_mask', False)
+
+            # Per-face masking scope: restrict AI masking to a subset of views
+            # (e.g. only the face that contains the operator), leaving the other
+            # faces untouched. Useful when YOLO would otherwise mask people in
+            # paintings/posters on the other faces. None/empty => all faces.
+            mask_face_filter = normalize_mask_faces(job.settings.get('ai_mask_cameras', None))
+            if mask_face_filter:
+                logger.info(f"AI masking restricted to faces: {sorted(mask_face_filter)}")
 
             # Interpolation Settings
             interp_mode = job.settings.get('interpolation_mode', 'linear')
@@ -384,11 +393,29 @@ class ProcessingWorker(QObject):
                     ai_results = []
                     if batch_images:
                         if self.ai_service and ai_mode_internal != 'none':
-                            ai_results = self.ai_service.process_batch(
-                                batch_images, mode=ai_mode_internal, conf=ai_confidence,
-                                classes=target_classes, invert_mask=ai_invert_mask,
-                                feather_mask=ai_feather_mask
-                            )
+                            if mask_face_filter is None:
+                                ai_results = self.ai_service.process_batch(
+                                    batch_images, mode=ai_mode_internal, conf=ai_confidence,
+                                    classes=target_classes, invert_mask=ai_invert_mask,
+                                    feather_mask=ai_feather_mask
+                                )
+                            else:
+                                # Only run inference on the selected faces; the
+                                # rest pass through untouched (no mask, never skipped).
+                                eligible_idx = [
+                                    i for i, n in enumerate(batch_names)
+                                    if n.lower() in mask_face_filter
+                                ]
+                                ai_results = [(img, None) for img in batch_images]
+                                if eligible_idx:
+                                    sub_results = self.ai_service.process_batch(
+                                        [batch_images[i] for i in eligible_idx],
+                                        mode=ai_mode_internal, conf=ai_confidence,
+                                        classes=target_classes, invert_mask=ai_invert_mask,
+                                        feather_mask=ai_feather_mask
+                                    )
+                                    for slot, res in zip(eligible_idx, sub_results):
+                                        ai_results[slot] = res
                         else:
                             ai_results = [(img, None) for img in batch_images]
 

--- a/src/core/settings_manager.py
+++ b/src/core/settings_manager.py
@@ -20,6 +20,7 @@ class SettingsManager:
         "ai_detect_vehicles": False,
         "ai_detect_plants": False,
         "ai_custom_classes": "",
+        "ai_mask_cameras": [],
         "quality": 95,
         "output_format": "jpg",
         "custom_output_dir": "",
@@ -99,6 +100,22 @@ class SettingsManager:
         """Return a copy of all settings."""
         return self.settings.copy()
 
+def normalize_mask_faces(ai_mask_cameras):
+    """Normalize a per-face mask selection into a lowercase set of face names.
+
+    Accepts a list of names or a comma-separated string. Returns ``None`` when
+    no face is selected, meaning AI masking applies to every face (the default,
+    backward-compatible behavior). Returning a set makes membership tests in the
+    processor case-insensitive.
+    """
+    if not ai_mask_cameras:
+        return None
+    if isinstance(ai_mask_cameras, str):
+        ai_mask_cameras = ai_mask_cameras.split(',')
+    faces = {str(c).strip().lower() for c in ai_mask_cameras if str(c).strip()}
+    return faces or None
+
+
 def build_settings(args, config, active_cameras=None, output_path=""):
     """Assemble the settings dict consumed by the processor.
 
@@ -168,6 +185,18 @@ def build_settings(args, config, active_cameras=None, output_path=""):
     # Telemetry.
     if getattr(args, 'export_telemetry', False):
         settings['export_telemetry'] = True
+
+    # Per-face masking scope. Accepts a comma-separated string ("Down,Back") on
+    # the CLI or a list in the config file. Normalized to a list of face names;
+    # empty => mask every face (default).
+    if getattr(args, 'ai_mask_cameras', None) is not None:
+        settings['ai_mask_cameras'] = [
+            c.strip() for c in args.ai_mask_cameras.split(',') if c.strip()
+        ]
+    else:
+        raw = settings.get('ai_mask_cameras', [])
+        if isinstance(raw, str):
+            settings['ai_mask_cameras'] = [c.strip() for c in raw.split(',') if c.strip()]
 
     # AI detection targets.
     if args.targets is not None:

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,4 +1,4 @@
 APP_NAME = "360 Extractor"
-VERSION = "3.1.1"
+VERSION = "3.2.0"
 AUTHOR = "Nicolas Diolez"
 LICENSE = "AGPL-3.0"

--- a/src/core/version.py
+++ b/src/core/version.py
@@ -1,4 +1,4 @@
 APP_NAME = "360 Extractor"
-VERSION = "3.1.0"
+VERSION = "3.1.1"
 AUTHOR = "Nicolas Diolez"
 LICENSE = "AGPL-3.0"

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ def parse_arguments():
     # AI Targets
     parser.add_argument("--targets", type=str, help="Comma-separated list of basic targets (humans,vehicles,plants)")
     parser.add_argument("--custom-classes", type=str, help="Custom classes to detect (comma separated)")
+    parser.add_argument("--ai-mask-cameras", type=str, help="Restrict AI masking to these faces only, comma-separated (e.g. 'Down' or 'Back,Down'; cube faces: Front,Right,Back,Left,Up,Down; ring/fibonacci: View_0,View_1,...). Empty = all faces.")
     
     # Naming Control
     parser.add_argument("--naming-mode", type=str, choices=['realityscan', 'simple', 'custom'], help="Naming convention for output files")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QPushButton, QLabel, QSpinBox,
     QComboBox, QFileDialog, QProgressBar, QMessageBox,
     QDoubleSpinBox, QCheckBox, QSplitter, QScrollArea, QStackedWidget,
-    QLineEdit
+    QLineEdit, QGridLayout
 )
 from PySide6.QtCore import Qt, QFile, QTextStream, QThread, QEvent, QObject, QSize
 
@@ -622,7 +622,24 @@ class MainWindow(QMainWindow):
         custom_row.addWidget(self.btn_view_classes)
         
         ai_section.addLayout(custom_row)
-        
+
+        # Per-face masking scope (Cube layout only). When no face is checked,
+        # masking applies to every face (default). Selecting one or more faces
+        # restricts masking to them — e.g. mask the operator on "Down" without
+        # masking people in paintings on the other faces.
+        self.mask_faces_label = QLabel("Mask only on faces (none = all):")
+        ai_section.addWidget(self.mask_faces_label)
+
+        self.mask_face_checks = {}
+        mask_faces_grid = QGridLayout()
+        cube_faces = ["Front", "Right", "Back", "Left", "Up", "Down"]
+        for i, face in enumerate(cube_faces):
+            chk = QCheckBox(face)
+            chk.toggled.connect(self.on_setting_changed)
+            self.mask_face_checks[face] = chk
+            mask_faces_grid.addWidget(chk, i // 3, i % 3)
+        ai_section.addLayout(mask_faces_grid)
+
         content_layout.addWidget(ai_section)
         
         # Blur Section
@@ -849,6 +866,9 @@ class MainWindow(QMainWindow):
             'ai_detect_vehicles': self.chk_vehicles.isChecked(),
             'ai_detect_plants': self.chk_plants.isChecked(),
             'ai_custom_classes': self.txt_custom_classes.text(),
+            'ai_mask_cameras': [
+                name for name, chk in self.mask_face_checks.items() if chk.isChecked()
+            ],
             'adaptive_mode': self.adaptive_toggle.isChecked(),
             'adaptive_threshold': self.motion_threshold_spin.value(),
             'blur_filter_enabled': self.blur_toggle.isChecked(),
@@ -874,6 +894,7 @@ class MainWindow(QMainWindow):
             self.lanczos_toggle, self.ai_feather_toggle, self.input_360_toggle,
             self.altitude_combo
         ]
+        widgets += list(self.mask_face_checks.values())
         for w in widgets:
             w.blockSignals(True)
 
@@ -910,7 +931,14 @@ class MainWindow(QMainWindow):
         self.chk_vehicles.setChecked(settings.get('ai_detect_vehicles', False))
         self.chk_plants.setChecked(settings.get('ai_detect_plants', False))
         self.txt_custom_classes.setText(settings.get('ai_custom_classes', ""))
-        
+
+        mask_faces = settings.get('ai_mask_cameras', []) or []
+        if isinstance(mask_faces, str):
+            mask_faces = [c.strip() for c in mask_faces.split(',') if c.strip()]
+        mask_faces_lower = {str(f).strip().lower() for f in mask_faces}
+        for name, chk in self.mask_face_checks.items():
+            chk.setChecked(name.lower() in mask_faces_lower)
+
         self.blur_toggle.setChecked(settings.get('blur_filter_enabled', False))
         self.smart_blur_toggle.setChecked(settings.get('smart_blur_enabled', False))
         self.blur_threshold_spin.setValue(settings.get('blur_threshold', 100.0))
@@ -954,7 +982,8 @@ class MainWindow(QMainWindow):
     def on_setting_changed(self):
         if self.is_processing:
             return
-            
+
+        self._update_mask_faces_state()
         current_settings = self.get_settings_from_ui()
         
         if self._selected_cards:
@@ -996,6 +1025,19 @@ class MainWindow(QMainWindow):
             self.cam_count_spin.setEnabled(self.layout_combo.currentData() != 'cube')
         else:
             self.cam_count_spin.setEnabled(False)
+        self._update_mask_faces_state()
+
+    def _update_mask_faces_state(self):
+        """Per-face masking is named-face based, so it's GUI-exposed for the Cube
+        layout only, and only meaningful when an AI mode is active on 360 input."""
+        enabled = (
+            self.input_360_toggle.isChecked()
+            and self.layout_combo.currentData() == 'cube'
+            and self.ai_combo.currentText() != 'None'
+        )
+        self.mask_faces_label.setEnabled(enabled)
+        for chk in self.mask_face_checks.values():
+            chk.setEnabled(enabled)
 
     def on_blur_toggled(self, checked):
         self.blur_threshold_spin.setEnabled(checked)

--- a/tests/test_cli_settings.py
+++ b/tests/test_cli_settings.py
@@ -15,7 +15,7 @@ import unittest
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from core.settings_manager import SettingsManager, build_settings
+from core.settings_manager import SettingsManager, build_settings, normalize_mask_faces
 
 SRC_DIR = os.path.join(os.path.dirname(__file__), '..', 'src')
 
@@ -34,7 +34,7 @@ def make_args(**overrides):
         resolution=None, layout=None, flat=False,
         adaptive=False, motion_threshold=None,
         export_telemetry=False, altitude_mode=None,
-        targets=None, custom_classes=None,
+        targets=None, custom_classes=None, ai_mask_cameras=None,
         naming_mode=None, image_pattern=None, mask_pattern=None,
     )
     defaults.update(overrides)
@@ -132,6 +132,53 @@ class TestBuildSettings(unittest.TestCase):
         self.assertEqual(build_settings(make_args(ai_mask=True), {})['ai_mode'], 'Generate Mask')
         # Legacy boolean 'ai' key in an older config still enables masking.
         self.assertEqual(build_settings(make_args(), {'ai': True})['ai_mode'], 'Generate Mask')
+
+    def test_ai_mask_cameras_default_is_empty(self):
+        """No selection => empty list, i.e. mask every face (current behavior)."""
+        self.assertEqual(build_settings(make_args(), config={})['ai_mask_cameras'], [])
+
+    def test_ai_mask_cameras_cli_parsing(self):
+        """The CLI accepts a comma-separated face list, trimmed into a clean list."""
+        settings = build_settings(make_args(ai_mask_cameras=' Down , Back '), config={})
+        self.assertEqual(settings['ai_mask_cameras'], ['Down', 'Back'])
+
+    def test_ai_mask_cameras_cli_overrides_config(self):
+        settings = build_settings(
+            make_args(ai_mask_cameras='Down'), config={'ai_mask_cameras': ['Front', 'Back']}
+        )
+        self.assertEqual(settings['ai_mask_cameras'], ['Down'])
+
+    def test_ai_mask_cameras_config_string_normalized_to_list(self):
+        """A config value stored as a string is normalized to a list."""
+        settings = build_settings(make_args(), config={'ai_mask_cameras': 'Up, Down'})
+        self.assertEqual(settings['ai_mask_cameras'], ['Up', 'Down'])
+
+    def test_ai_mask_cameras_config_list_passthrough(self):
+        settings = build_settings(make_args(), config={'ai_mask_cameras': ['Back']})
+        self.assertEqual(settings['ai_mask_cameras'], ['Back'])
+
+
+class TestNormalizeMaskFaces(unittest.TestCase):
+    """Tests for the per-face masking scope helper used by the processor."""
+
+    def test_empty_means_all_faces(self):
+        # None/empty => None sentinel => the processor masks every face.
+        self.assertIsNone(normalize_mask_faces(None))
+        self.assertIsNone(normalize_mask_faces([]))
+        self.assertIsNone(normalize_mask_faces(""))
+        self.assertIsNone(normalize_mask_faces(["", "  "]))
+
+    def test_list_lowercased_set(self):
+        self.assertEqual(normalize_mask_faces(["Down", "Back"]), {"down", "back"})
+
+    def test_string_parsed_and_trimmed(self):
+        self.assertEqual(normalize_mask_faces(" Down , Back "), {"down", "back"})
+
+    def test_membership_is_case_insensitive(self):
+        faces = normalize_mask_faces(["Down"])
+        self.assertIn("down", faces)
+        # The processor compares name.lower() in faces, so casing never matters.
+        self.assertIn("Down".lower(), faces)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Implements **per-face AI masking scope** (issue #14). AI masking can now be restricted to a subset of cubemap faces instead of being applied to every extracted view.

**Why:** YOLO detects the `person` class whether it's a real person or a figure in a painting/poster. When filming a museum, masking the operator also masked people in the artworks. Users had to delete masks face-by-face manually.

**Now:** select only the face(s) containing the operator (e.g. `Down` or `Back`) — the other faces are left untouched. Inference only runs on the selected faces, so it's also slightly cheaper.

## Changes

- **Core** (`processor.py`): the AI step runs inference only on the selected faces; the rest pass through as `(img, None)` — no mask file, never skipped.
- **Settings** (`settings_manager.py`): new key `ai_mask_cameras` (list of face names; empty/None = all faces, fully backward-compatible) + testable `normalize_mask_faces()` helper.
- **CLI** (`main.py`): `--ai-mask-cameras "Down,Back"`.
- **GUI** (`main_window.py`): face checkboxes under "AI Processing", enabled for the Cube layout when an AI mode is active.
- **Tests**: 9 new tests (CLI/config parsing + helper). 51 pass, ruff clean.
- **Docs**: README banner + feature line, CHANGELOG (**3.2.0**), CLI.md, SETTINGS.md. Version bumped to `3.2.0`.

## Design notes

- Faces are matched **by name** (case-insensitive): `Front,Right,Back,Left,Up,Down` for Cube; `View_0,View_1,…` for ring/fibonacci.
- The GUI checkboxes are Cube-only (named faces); CLI users can target `View_N` for other layouts.
- Minor version bump (new feature, no breaking change — default behavior is unchanged).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)