### PR TITLE
docs: product name (360 Extractor) + evergreen README banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to 360 Extractor Pro will be documented in this file.
+All notable changes to 360 Extractor will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# 360 Extractor Pro
+# 360 Extractor
 
 High-performance desktop application and command-line tool for 360° and standard video/image preprocessing. This tool generates optimized datasets for Gaussian Splatting and photogrammetry (COLMAP, RealityScan) by converting equirectangular media into rectilinear pinhole views and removing operators using AI.
 
-> **v3.2.0** - Added **per-face AI masking**: restrict operator removal to specific cubemap faces (e.g. mask only `Down`/`Back`) so people in paintings/posters on the other faces are left untouched. See the [CHANGELOG](CHANGELOG.md) for details and prior releases.
+> See the [CHANGELOG](CHANGELOG.md) for what's new in each release.
 
 ## Key Features
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # CLI Mode Documentation
 
-This document provides detailed information about using the 360 Extractor Pro in headless mode. This is ideal for automation or server environments.
+This document provides detailed information about using 360 Extractor in headless mode. This is ideal for automation or server environments.
 
 ## Overview
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,6 +1,6 @@
 # Settings and Configuration Guide
 
-This guide explains the various settings available in the 360 Extractor Pro GUI and how to use JSON configuration files for batch processing and CLI mode.
+This guide explains the various settings available in the 360 Extractor GUI and how to use JSON configuration files for batch processing and CLI mode.
 
 ## Core Settings
 

--- a/setup_cuda.py
+++ b/setup_cuda.py
@@ -68,7 +68,7 @@ def run_command(command, description):
         return False
 
 def setup_gpu():
-    print_step("360 Extractor Pro - PyTorch CUDA Setup Helper")
+    print_step("360 Extractor - PyTorch CUDA Setup Helper")
     
     # 1. OS Check
     is_win = sys.platform.startswith('win')


### PR DESCRIPTION
Docs-only hotfix for `main`:

- The app has always called itself **360 Extractor** (window title, `--version`, EXIF `Software` tag) — "Pro" only survived in the README title and doc headings. Docs now match reality.
- The README version banner was stuck at **v3.2.0** (both the 3.2.1 and 3.3.0 releases forgot it). Replaced with an evergreen pointer to the CHANGELOG so it structurally cannot rot again.

No code changes; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)